### PR TITLE
Update for Crystal 1.13

### DIFF
--- a/src/lib/value_types/base.cr
+++ b/src/lib/value_types/base.cr
@@ -15,7 +15,7 @@ module Optarg::ValueTypes
       end
 
       {% if et %}
-        alias ElementType = {{et}}
+        alias ElementType = ::{{et.id}}
         alias ElementValue = ::Optarg::ValueTypes::{{et.id}}::Value
       {% end %}
 

--- a/src/lib/value_types/string_array.cr
+++ b/src/lib/value_types/string_array.cr
@@ -1,6 +1,6 @@
 module Optarg::ValueTypes
   class StringArray < Base
-    __concrete Array(::String), et: ::String
+    __concrete Array(::String), et: String
 
     class Value
       def compare_to(other)


### PR DESCRIPTION
Tried to compile an Amber project on Crystal 1.13.1, which failed because of this change in Crystal: https://github.com/crystal-lang/crystal/pull/14490

This change fixes it at the expense of slight asymmetry in the arguments to the `__concrete` macro.