### PR TITLE
Fix version number in shard.yml.

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: optarg
-version: 0.9.3
+version: 0.9.5
 
 authors:
   - mosop


### PR DESCRIPTION
This need a new tag v0.9.5.

This fixes the warning when installing amber:

```
Shard "optarg" version (0.9.3) doesn't match tag version (0.9.4)
```

@crimson-knight 